### PR TITLE
Removed 'Readme' title from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# Readme
-
 ## Shade-Plugins (Pro Version Only)
 
 Shade now supports custom export plugins. This is an experimental feature, allowing for custom export options of shaders to different platforms/engines.


### PR DESCRIPTION
@JohnTM doing this because the title of the view already says "README.md" in Shade's UI so this one is better left out