### PR TITLE
Missing comma in unlit fragment

### DIFF
--- a/ThreeJSExport/Export.lua
+++ b/ThreeJSExport/Export.lua
@@ -262,7 +262,7 @@ THREE.{{name_no_spaces}}Shader = {
         	"gl_FragColor = vec4( outgoingLight, diffuseColor.a );",
             {{/physical}}
             {{#unlit}}
-            "gl_FragColor = vec4( diffuseColor.rgb + emissive, diffuseColor.a );"
+            "gl_FragColor = vec4( diffuseColor.rgb + emissive, diffuseColor.a );",
             {{/unlit}}
 
         	"#include <tonemapping_fragment>",


### PR DESCRIPTION
Absolutely love the work you've done here! I noticed a syntax error when I exported to Three.js, so I added a quick fix.

It also looks like a few of the functions aren't implemented in the exported Three.js shader yet:

```
vec3 split_2 = /* POSITION NOT IMPLEMENTED */;
float multiply_13 = ((1.0 - dot(/* NORMAL NOT IMPLEMENTED */, /* VIEWDIR NOT IMPLEMENTED */)) * remap(sin((split_2.g* /* ...etc... */
```

Are these items you're working on now or are you looking for a hand with them? Thanks so much for the app and the exporters, this is really excellent work!