### PR TITLE
switching emissive to input_emission

### DIFF
--- a/ThreeJSExport/Export.lua
+++ b/ThreeJSExport/Export.lua
@@ -224,6 +224,12 @@ THREE.{{name_no_spaces}}Shader = {
         "{{{three_uniform}}}",
         {{/uniforms}}
 
+        "float remap(float target, float fromLow, float fromHigh, float toLow, float toHigh){",
+            "float delta = (target - fromLow) / (fromHigh - fromLow);",
+            "float toRange = toHigh - toLow;",
+            "return toLow + toRange * delta;",
+        "}",
+
 		"void main() {",
             {{#frag}}
             "{{{three_surface_output}}}",

--- a/ThreeJSExport/Export.lua
+++ b/ThreeJSExport/Export.lua
@@ -239,7 +239,7 @@ THREE.{{name_no_spaces}}Shader = {
 
             {{#physical}}
         	"ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );",
-        	"vec3 totalEmissiveRadiance = emissive;",
+        	"vec3 totalEmissiveRadiance = input_emission;",
 
         	"#include <logdepthbuf_fragment>",
         	"#include <map_fragment>",


### PR DESCRIPTION
Hey again! When doing a ThreeJS export of both (a) a Shade scene with no nodes and (b) a Shade scene with a single Color node mapped to the Emission property, I was getting this error:

<img width="503" alt="ThreeJS error - undeclared identifier 'emissive'" src="https://user-images.githubusercontent.com/5344587/81411988-23d73780-9111-11ea-8b97-9f6af5de3391.png">

I saw that there was an `input_emission` vec3 declared by both of those shaders, so this PR switches the undeclared `emissive` reference to an `input_emission` reference. This makes both of the scenarios I described above export functional ThreeJS shaders directly from the app, with working emission values if any are set.

(More info: I saw that `vec3 emissive` was being declared in the Lambert, Phong, and Physical fragment snippets:

<img width="540" alt="vec3 emissive highlighted in lambert, phong, and physical fragment snippets" src="https://user-images.githubusercontent.com/5344587/81412497-f3dc6400-9111-11ea-965a-13c24136c53c.png">

but couldn't find any implementation of those snippets in the `ThreeJSExport/Export.lua` template. My fix might end up being naive when it comes to more advanced use of those different lighting models but it's working for simple export!)