### PR TITLE
Fix syntax error in Three.js export

### DIFF
--- a/ThreeJSExport/Export.lua
+++ b/ThreeJSExport/Export.lua
@@ -143,9 +143,11 @@ THREE.{{name_no_spaces}}Shader = {
         "{{{three_uniform}}}",
         {{/uniforms}}
 
+        `
 		{{#vert_funcs}}
 		{{{.}}}
 		{{/vert_funcs}}
+        `,
 
 		"void main() {",
 
@@ -228,9 +230,11 @@ THREE.{{name_no_spaces}}Shader = {
         "{{{three_uniform}}}",
         {{/uniforms}}
 
+        `
 		{{#frag_funcs}}
 		{{{.}}}
 		{{/frag_funcs}}
+        `,
 
 		"void main() {",
             {{#frag}}


### PR DESCRIPTION
This fixes a small syntax error in the generated output for Three.js by wrapping the outputted shader code in a template string